### PR TITLE
Fix enablePrivateClusterPublicFQDN to force the cluster to use the ex…

### DIFF
--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/aks/privateaks.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/aks/privateaks.bicep
@@ -71,6 +71,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2022-01-02-previ
     apiServerAccessProfile: {
       enablePrivateCluster: true
       privateDNSZone: privateDNSZoneId
+      enablePrivateClusterPublicFQDN: false
     }
     enableRBAC: true
     aadProfile: {


### PR DESCRIPTION
AKS changed the behavior of the cluster FQDN and it's now adding a public FQDN pointing to the private IP of the cluster. This is not the intent behavior for a secure cluster. Here is the change that will revert the expected behavior to use a private endpoint using the internal private dns for it.

Reference: https://docs.microsoft.com/en-us/azure/aks/private-clusters#disable-public-fqdn
