### PR TITLE
Broken link for AKSC Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use [this repo](https://github.com/Azure/AKS-Landing-Zone-Accelerator/tree/main/
 
 A flexible templating approach using Bicep that enables multiple scenarios using a Web based tool. It provides tangible artifacts to **quickly** enable AKS deployments through CLI or in your CI/CD pipeline.
 
-Driving the configuration experience is a [wizard](https://azure.github.io/Aks-Construction/?default=es) to guide your decision making, it provides presets for the main Azure Landing Zone deployment modes (Sandbox, Corp & Online). The output of this wizard experience are the parameters and CLI commands to immediately deploy using our maintained Bicep template to deploy your customized AKS environment in one step.
+Driving the configuration experience is a [wizard](https://azure.github.io/AKS-Construction/?default=es) to guide your decision making, it provides presets for the main Azure Landing Zone deployment modes (Sandbox, Corp & Online). The output of this wizard experience are the parameters and CLI commands to immediately deploy using our maintained Bicep template to deploy your customized AKS environment in one step.
 
 Use [this repo](https://github.com/Azure/Aks-Construction) if you would like to use a guided experience to rapidly create your environment with a maintained Bicep template based on the architecture of the AKS Secure Baseline.
 


### PR DESCRIPTION
Looks like this link was broken when the repo name was changed.