### PR TITLE
change to use Ubuntu v.20.04

### DIFF
--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-Hub/modules/compute-linux/compute-linux.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-Hub/modules/compute-linux/compute-linux.tf
@@ -64,13 +64,13 @@ variable "location" {}
 
 variable "vnet_subnet_id" {}
 variable "os_publisher" {
-  default = "Canonical"
+  default = "canonical"
 }
 variable "os_offer" {
-  default = "UbuntuServer"
+  default = "0001-com-ubuntu-server-focal"
 }
 variable "os_sku" {
-  default = "18.04-LTS"
+  default = "20_04-lts-gen2"
 }
 variable "os_version" {
   default = "latest"


### PR DESCRIPTION
Ubuntu v.18.04 has been out of support since May 31st, 2023.
Need to change OS version of Bastion VM to avoid end-of-support Ubuntu version.

