### PR TITLE
Update Bicep to newer VM size, newer OS and set K8s version to 1.26

### DIFF
--- a/.github/workflows/1-deploy-infrastructure.yml
+++ b/.github/workflows/1-deploy-infrastructure.yml
@@ -223,7 +223,7 @@ jobs:
             RUNNER_MANAGED_IDENTITY_PRINCIPAL_ID="$(az resource list -n ${{ env.RUNNER_VM_NAME }} --query [*].identity.principalId --out tsv)"
             echo 'RUNNER_MANAGED_IDENTITY_PRINCIPAL_ID='$RUNNER_MANAGED_IDENTITY_PRINCIPAL_ID >> $GITHUB_ENV
           
-            AKS_VERSION=$(az aks get-versions --location ${{ env.DEPLOYMENT_LOCATION }} --query "orchestrators[].orchestratorVersion | max(@)" --output tsv)
+            AKS_VERSION='1.26'
             echo 'AKS_VERSION='$AKS_VERSION >> $GITHUB_ENV 
 
       - name: Azure Log out

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/deploy-runner.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/deploy-runner.bicep
@@ -7,8 +7,8 @@ param vnetName string
 param vmName string = 'runner'
 param vmSize string
 param publisher string = 'Canonical'
-param offer string = 'UbuntuServer'
-param sku string = '18.04-LTS'
+param offer string = '0001-com-ubuntu-server-focal'
+param sku string = '20_04-lts-gen2'
 param location string = deployment().location
 param adminUsername string
 @secure()

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/modules/VM/virtualmachine.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/modules/VM/virtualmachine.bicep
@@ -35,8 +35,8 @@ resource jumpbox 'Microsoft.Compute/virtualMachines@2021-03-01' = {
       }
       imageReference: {
         publisher: 'Canonical'
-        offer: 'UbuntuServer'
-        sku: '18.04-LTS'
+        offer: '0001-com-ubuntu-server-focal'
+        sku: '20_04-lts-gen2'
         version: 'latest'
       }
     }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/aks/privateaks.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/aks/privateaks.bicep
@@ -18,7 +18,7 @@ param autoScalingProfile object
 param networkPlugin string = 'azure'
 //param appGatewayIdentityResourceId string
 
-resource aksCluster 'Microsoft.ContainerService/managedClusters@2022-01-02-preview' = {
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2022-03-02-preview' = {
   name: clusterName
   location: location
   identity: {
@@ -45,7 +45,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2022-01-02-previ
         count: 3
         minCount: enableAutoScaling ? 1 : null
         maxCount: enableAutoScaling ? 3 : null
-        vmSize: 'Standard_DS2_v2'
+        vmSize: 'Standard_D4d_v5'
         osDiskSizeGB: 30
         type: 'VirtualMachineScaleSets'
         vnetSubnetID: subnetId


### PR DESCRIPTION
* Update VM linux OS to 20_04-lts-gen2 in Bicep files

* Updated Github Action (1-deploy-infrastructure.yml) to set K8s version to 1.26

* Update Microsoft.ContainerService/managedClusters to API version 2022-03-02-preview in order to get aliased kubernetes version support

* Set AKS VM node size to Standard_D4d_v5 to avoid perf issues with demo workload