### PR TITLE
Move Azure Policy location to parameter

### DIFF
--- a/.github/workflows/1-deploy-infrastructure.yml
+++ b/.github/workflows/1-deploy-infrastructure.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   BICEP_ROOT_PATH: Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/
-  DEPLOYMENT_LOCATION: eastus
+  DEPLOYMENT_LOCATION: westus2
   HUB_RESOURCE_GROUP: ESLZ-HUB
   SPOKE_RESOURCE_GROUP: ESLZ-SPOKE
   MANAGED_RESOURCE_GROUP: eslzakscluster-aksInfraRG

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/deploy-vm.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/deploy-vm.bicep
@@ -7,6 +7,7 @@ param vnetName string
 param pubkeydata string
 param vmSize string
 param location string = deployment().location
+@secure()
 param adminUsername string
 @secure()
 param adminPassword string

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/deploy-vm.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/deploy-vm.bicep
@@ -8,6 +8,7 @@ param pubkeydata string
 param vmSize string
 param location string = deployment().location
 param adminUsername string
+@secure()
 param adminPassword string
 
 resource subnetVM 'Microsoft.Network/virtualNetworks/subnets@2020-11-01' existing = {

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/main.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/main.bicep
@@ -173,18 +173,26 @@ module routetableroutes 'modules/vnet/routetableroutes.bicep' = {
 }
 
 //  Telemetry Deployment
-@description('Enable usage and telemetry feedback to Microsoft.')
-param enableTelemetry bool = true
-var telemetryId = '0d807b2d-f7c3-4710-9a65-e88257df1ea0-${location}'
-resource telemetrydeployment 'Microsoft.Resources/deployments@2021-04-01' = if (enableTelemetry) {
-  name: telemetryId
-  location: location
-  properties: {
-    mode: 'Incremental'
-    template: {
-      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#'
-      contentVersion: '1.0.0.0'
-      resources: {}
-    }
+module telemetry 'modules/telemetry/telemetry.bicep' = {
+  name: 'telemetry'
+  params: {
+    location: location
+    enableTelemetry: true
   }
 }
+
+// @description('Enable usage and telemetry feedback to Microsoft.')
+// param enableTelemetry bool = true
+// var telemetryId = '0d807b2d-f7c3-4710-9a65-e88257df1ea0-${location}'
+// resource telemetrydeployment 'Microsoft.Resources/deployments@2021-04-01' = if (enableTelemetry) {
+//   name: telemetryId
+//   location: location
+//   properties: {
+//     mode: 'Incremental'
+//     template: {
+//       '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#'
+//       contentVersion: '1.0.0.0'
+//       resources: {}
+//     }
+//   }
+// }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/modules/VM/virtualmachine.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/modules/VM/virtualmachine.bicep
@@ -2,7 +2,9 @@ param subnetId string
 param publicKey string
 param vmSize string
 param location string = resourceGroup().location
+@secure()
 param adminUsername string
+@secure()
 param adminPassword string
 //param script64 string
 

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/modules/telemetry/telemetry.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/modules/telemetry/telemetry.bicep
@@ -1,7 +1,9 @@
+targetScope = 'subscription'
+
 @description('Enable usage and telemetry feedback to Microsoft.')
 
 param enableTelemetry bool = true
-param location string = deployment().location
+param location string
 
 var telemetryId = '0d807b2d-f7c3-4710-9a65-e88257df1ea0-${location}'
 

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/modules/telemetry/telemetry.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/03-Network-Hub/modules/telemetry/telemetry.bicep
@@ -1,0 +1,19 @@
+@description('Enable usage and telemetry feedback to Microsoft.')
+
+param enableTelemetry bool = true
+param location string = deployment().location
+
+var telemetryId = '0d807b2d-f7c3-4710-9a65-e88257df1ea0-${location}'
+
+resource telemetrydeployment 'Microsoft.Resources/deployments@2021-04-01' = if (enableTelemetry) {
+  name: telemetryId
+  location: location
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#'
+      contentVersion: '1.0.0.0'
+      resources: {}
+    }
+  }
+}

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/main.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/main.bicep
@@ -244,18 +244,26 @@ module appgwroutetableroutes 'modules/vnet/routetableroutes.bicep' = [for i in r
 }]
 
 //  Telemetry Deployment
-@description('Enable usage and telemetry feedback to Microsoft.')
-param enableTelemetry bool = true
-var telemetryId = 'a4c036ff-1c94-4378-862a-8e090a88da82-${location}'
-resource telemetrydeployment 'Microsoft.Resources/deployments@2021-04-01' = if (enableTelemetry) {
-  name: telemetryId
-  location: location
-  properties: {
-    mode: 'Incremental'
-    template: {
-      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#'
-      contentVersion: '1.0.0.0'
-      resources: {}
-    }
+module telemetry 'modules/telemetry/telemetry.bicep' = {
+  name: 'telemetry'
+  params: {
+    enableTelemetry: true
+    location: location
   }
 }
+
+// @description('Enable usage and telemetry feedback to Microsoft.')
+// param enableTelemetry bool = true
+// var telemetryId = 'a4c036ff-1c94-4378-862a-8e090a88da82-${location}'
+// resource telemetrydeployment 'Microsoft.Resources/deployments@2021-04-01' = if (enableTelemetry) {
+//   name: telemetryId
+//   location: location
+//   properties: {
+//     mode: 'Incremental'
+//     template: {
+//       '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#'
+//       contentVersion: '1.0.0.0'
+//       resources: {}
+//     }
+//   }
+// }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/main.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/main.bicep
@@ -70,7 +70,9 @@ resource pvtdnsAKSZone 'Microsoft.Network/privateDnsZones@2020-06-01' existing =
 module aksPolicy 'modules/policy/policy.bicep' = {
   scope: resourceGroup(rg.name)
   name: 'aksPolicy'
-  params: {}
+  params: {
+    location: location
+  }
 }
 
 module akslaworkspace 'modules/laworkspace/la.bicep' = {
@@ -157,7 +159,6 @@ module aksPvtDNSContrib 'modules/Identity/pvtdnscontribrole.bicep' = {
   scope: resourceGroup(rg.name)
   name: 'aksPvtDNSContrib'
   params: {
-    location: location
     principalId: aksIdentity.properties.principalId
     roleGuid: 'b12aa53e-6015-4669-85d0-8515ebb3ae7f' //Private DNS Zone Contributor
     pvtdnsAKSZoneName: privateDNSZoneAKSName

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/Identity/pvtdnscontribrole.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/Identity/pvtdnscontribrole.bicep
@@ -1,6 +1,5 @@
 param principalId string
 param roleGuid string
-param location string = resourceGroup().location
 param pvtdnsAKSZoneName string
 
 resource pvtdnsAKSZone 'Microsoft.Network/privateDnsZones@2020-06-01' existing = {

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/aks/privateaks.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/aks/privateaks.bicep
@@ -18,7 +18,7 @@ param autoScalingProfile object
 param networkPlugin string = 'azure'
 //param appGatewayIdentityResourceId string
 
-resource aksCluster 'Microsoft.ContainerService/managedClusters@2022-03-02-preview' = {
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-02-preview' = {
   name: clusterName
   location: location
   identity: {

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/aks/privateaks.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/aks/privateaks.bicep
@@ -18,7 +18,7 @@ param autoScalingProfile object
 param networkPlugin string = 'azure'
 //param appGatewayIdentityResourceId string
 
-resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-02-preview' = {
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
   name: clusterName
   location: location
   identity: {

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/aks/privateaks.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/aks/privateaks.bicep
@@ -18,7 +18,7 @@ param autoScalingProfile object
 param networkPlugin string = 'azure'
 //param appGatewayIdentityResourceId string
 
-resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2022-04-01' = {
   name: clusterName
   location: location
   identity: {

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/policy/policy.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/policy/policy.bicep
@@ -1,6 +1,8 @@
+param location string = resourceGroup().location
+
 resource DefAKSAssignment 'Microsoft.Authorization/policyAssignments@2021-06-01' = if (environment().name == 'AzureCloud') {
   name: 'EnableDefenderForAKS'
-  location: resourceGroup().location
+  location: location
   properties: {
     policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/64def556-fbad-4622-930e-72d1d5589bf5'
   }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/policy/policy.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/policy/policy.bicep
@@ -1,10 +1,11 @@
 param location string = resourceGroup().location
+param policySetDefinitionId string = '/providers/Microsoft.Authorization/policyDefinitions/64def556-fbad-4622-930e-72d1d5589bf5'
 
 resource DefAKSAssignment 'Microsoft.Authorization/policyAssignments@2021-06-01' = if (environment().name == 'AzureCloud') {
   name: 'EnableDefenderForAKS'
   location: location
   properties: {
-    policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/64def556-fbad-4622-930e-72d1d5589bf5'
+    policyDefinitionId: policySetDefinitionId
   }
   identity: {
     type: 'SystemAssigned'

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/telemetry/telemetry.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/telemetry/telemetry.bicep
@@ -1,0 +1,21 @@
+//  Telemetry Deployment
+@description('Enable usage and telemetry feedback to Microsoft.')
+
+param enableTelemetry bool = true
+param location string = deployment().location
+
+var telemetryId = 'a4c036ff-1c94-4378-862a-8e090a88da82-${location}'
+
+resource telemetrydeployment 'Microsoft.Resources/deployments@2021-04-01' = if (enableTelemetry) {
+  name: telemetryId
+  location: location
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#'
+      contentVersion: '1.0.0.0'
+      resources: {}
+    }
+  }
+}
+

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/telemetry/telemetry.bicep
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Bicep/06-AKS-cluster/modules/telemetry/telemetry.bicep
@@ -1,8 +1,10 @@
+targetScope = 'subscription'
+
 //  Telemetry Deployment
 @description('Enable usage and telemetry feedback to Microsoft.')
 
 param enableTelemetry bool = true
-param location string = deployment().location
+param location string
 
 var telemetryId = 'a4c036ff-1c94-4378-862a-8e090a88da82-${location}'
 


### PR DESCRIPTION
This PR does the following
* Moves the Azure Policy location option to a parameter that satisfies the Bicep Linter and closes #119 
* Removes an unused location parameter
* Adds the `@secure()` option to username and password parameters where it was missing
* Changes the `managedCluster` apiversion to latest. Closes #122 