### PR TITLE
Implementation for Terraform All-in-One deployment

### DIFF
--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/03-Network-Hub/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/03-Network-Hub/main.tf
@@ -7,7 +7,7 @@ module "naming" {
 
 # rg is required for resource modules
 resource "azurerm_resource_group" "rg" {
-  location = "eastus" ##module.regions.regions[random_integer.region_index.result].name
+  location = var.location
   name     = var.rgHubName
 }
 
@@ -41,7 +41,7 @@ locals {
 module "avm-nsg-default" {
   source              = "Azure/avm-res-network-networksecuritygroup/azurerm"
   version             = "0.2.0"
-  name                = var.nsgDefaultName
+  name                = var.nsgHubDefaultName
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
 }
@@ -79,7 +79,6 @@ module "avm-res-network-virtualnetwork" {
     AzureFirewallSubnet = {
       name             = "AzureFirewallSubnet"
       address_prefixes = [var.snetFirewallAddr]
-
     }
     AzureBastionSubnet = {
       name             = "AzureBastionSubnet"
@@ -319,7 +318,7 @@ module "avm-res-network-routetable" {
   source              = "Azure/avm-res-network-routetable/azurerm"
   version             = "0.2.0"
   resource_group_name = azurerm_resource_group.rg.name
-  name                = var.rtName
+  name                = var.rtHubName
   location            = azurerm_resource_group.rg.location
 
   routes = {

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/03-Network-Hub/output.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/03-Network-Hub/output.tf
@@ -1,0 +1,15 @@
+output "vnetHubName" {
+  value = module.avm-res-network-virtualnetwork.name
+}
+
+output "rgHubName" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "vnetHubId" {
+  value = module.avm-res-network-virtualnetwork.resource_id
+}
+
+output "firewallPrivateIp" {
+  value = module.avm-res-network-azurefirewall.resource.ip_configuration.0.private_ip_address
+}

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/03-network-hub.md
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/03-network-hub.md
@@ -10,7 +10,7 @@ If you haven't yet, clone the repo and cd to the appropriate folder
 
 ```bash
 git clone https://github.com/Azure/AKS-Landing-Zone-Accelerator
-cd ./Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/02-EID
+cd ./Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/03-network-hub.md
 ```
 
 The following will be created:

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-LZ/input.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-LZ/input.tf
@@ -1,13 +1,13 @@
+variable "location" {
+  type    = string
+  default = "eastus"
+}
+
 variable "rgLzName" {
   type    = string
   default = "AksTerra-AVM-LZ-RG"
 }
 
-variable "location" {
-  type    = string
-  default = "eastus"
-
-}
 variable "rgHubName" {
   type    = string
   default = "AksTerra-AVM-Hub-RG"
@@ -18,30 +18,46 @@ variable "vnetHubName" {
   default = "vnet-hub"
 }
 
+variable "vnetHubId" {
+  type        = string
+  default     = ""
+  description = "Should be value from output of 03-Network-Hub. Used only when deploying All-in-One scenario."
+}
+
+variable "firewallPrivateIp" {
+  type        = string
+  default     = ""
+  description = "Should be value from output of 03-Network-Hub. Used only when deploying All-in-One scenario."
+}
+
+variable "deployingAllInOne" {
+  type    = bool
+  default = false
+}
+
 variable "vnetLzName" {
   type    = string
   default = "vnet-lz"
 }
-variable "rtName" {
+
+variable "rtLzName" {
   type    = string
   default = "rt-lz-table"
-
 }
-variable "nsgDefaultName" {
+
+variable "nsgLzDefaultName" {
   type    = string
   default = "nsg-default"
-
 }
+
 variable "nsgAppGWName" {
   type    = string
   default = "nsg-appgw"
-
 }
 
 variable "spokeVNETaddPrefixes" {
   type    = string
   default = "10.1.0.0/16"
-
 }
 
 variable "snetDefaultAddr" {
@@ -52,29 +68,24 @@ variable "snetDefaultAddr" {
 variable "snetAksAddr" {
   type    = string
   default = "10.1.1.0/26"
-
 }
 
 variable "snetAppGWAddr" {
   type    = string
   default = "10.1.2.0/27"
-
 }
 
 variable "snetVMAddr" {
   type    = string
   default = "10.1.3.0/27"
-
 }
 
 variable "snetServicePeAddr" {
   type    = string
   default = "10.1.4.0/27"
-
 }
 
 variable "routeAddr" {
   type    = string
   default = "0.0.0.0/0"
-
 }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-LZ/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-LZ/main.tf
@@ -2,25 +2,15 @@ locals {
   vnetHubId         = var.deployingAllInOne == true ? var.vnetHubId : data.azurerm_virtual_network.vnethub.0.id
   firewallPrivateIp = var.deployingAllInOne == true ? var.firewallPrivateIp : data.azurerm_firewall.firewall.0.ip_configuration.0.private_ip_address
 }
-# locals {
-#   vnetHubId         = var.vnetHubId != "" ? var.vnetHubId : data.azurerm_virtual_network.vnethub.0.id
-#   firewallPrivateIp = var.firewallPrivateIp != "" ? var.firewallPrivateIp : data.azurerm_firewall.firewall.0.ip_configuration.0.private_ip_address
-# }
-# locals {
-#   vnetHubId = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/${var.rgHubName}/providers/Microsoft.Network/virtualNetworks/${var.vnetHubName}"
-# }
-# data "azurerm_subscription" "current" {}
 
 data "azurerm_virtual_network" "vnethub" {
   count               = var.deployingAllInOne == true ? 0 : 1
-  # count               = var.vnetHubId == "" ? 1 : 0
   name                = var.vnetHubName
   resource_group_name = var.rgHubName
 }
 
 data "azurerm_firewall" "firewall" {
   count               = var.deployingAllInOne == true ? 0 : 1
-  # count               = var.firewallPrivateIp == "" ? 1 : 0
   name                = "azureFirewall"
   resource_group_name = var.rgHubName
 }
@@ -211,7 +201,7 @@ module "avm-res-network-vnet-peering" {
     resource_id = module.avm-res-network-vnet.resource.id
   }
   remote_virtual_network = {
-    resource_id = local.vnetHubId # data.azurerm_virtual_network.vnethub.id
+    resource_id = local.vnetHubId
   }
   name                                 = "local-to-remote"
   allow_forwarded_traffic              = true
@@ -246,7 +236,7 @@ module "avm-res-network-privatednszone-aks" {
   virtual_network_links = {
     vnetlink = {
       vnetlinkname     = "vlink-ak"
-      vnetid           = local.vnetHubId # data.azurerm_virtual_network.vnethub.id
+      vnetid           = local.vnetHubId
       autoregistration = false
   } }
 }
@@ -259,7 +249,7 @@ module "avm-res-network-privatednszone-akv" {
   virtual_network_links = {
     vnetlink = {
       vnetlinkname     = "vlink-akv"
-      vnetid           = local.vnetHubId # data.azurerm_virtual_network.vnethub.id
+      vnetid           = local.vnetHubId
       autoregistration = false
   } }
 
@@ -273,7 +263,7 @@ module "avm-res-network-privatednszone-acr" {
   virtual_network_links = {
     vnetlink = {
       vnetlinkname     = "vlink-acr"
-      vnetid           = local.vnetHubId # data.azurerm_virtual_network.vnethub.id
+      vnetid           = local.vnetHubId
       autoregistration = false
   } }
 }
@@ -286,7 +276,7 @@ module "avm-res-network-privatednszone-contoso" {
   virtual_network_links = {
     vnetlink = {
       vnetlinkname     = "vlink-contoso"
-      vnetid           = local.vnetHubId # data.azurerm_virtual_network.vnethub.id
+      vnetid           = local.vnetHubId
       autoregistration = false
   } }
 }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-LZ/output.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-LZ/output.tf
@@ -31,5 +31,5 @@ output "rgLzName" {
 }
 
 output "vnetLzName" {
-  value = module.avm-res-network-vnet.vnet.name 
+  value = module.avm-res-network-vnet.resource.name 
 }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-LZ/output.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-LZ/output.tf
@@ -2,10 +2,26 @@ output "speSubnetId" {
   value = module.avm-res-network-vnet-spe-subnet.resource_id
 }
 
-output "privateDnsZoneAkvId" {
+output "dnszoneAkvId" {
   value = module.avm-res-network-privatednszone-akv.resource_id
 }
 
-output "privateDnsZoneAcrId" {
+output "dnszoneAcrId" {
   value = module.avm-res-network-privatednszone-acr.resource_id
+}
+
+output "vnetLzId" {
+  value = module.avm-res-network-vnet.resource_id
+}
+
+output "snetAksId" {
+  value = module.avm-res-network-vnet-aks-subnet.resource_id
+}
+
+output "dnszoneAksId" {
+  value = module.avm-res-network-privatednszone-aks.resource_id
+}
+
+output "dnszoneContosoId" {
+  value = module.avm-res-network-privatednszone-contoso.resource_id
 }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-LZ/output.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-LZ/output.tf
@@ -25,3 +25,11 @@ output "dnszoneAksId" {
 output "dnszoneContosoId" {
   value = module.avm-res-network-privatednszone-contoso.resource_id
 }
+
+output "rgLzName" {
+  value = azurerm_resource_group.rg.name 
+}
+
+output "vnetLzName" {
+  value = module.avm-res-network-vnet.vnet.name 
+}

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-LZ/output.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/04-Network-LZ/output.tf
@@ -1,0 +1,11 @@
+output "speSubnetId" {
+  value = module.avm-res-network-vnet-spe-subnet.resource_id
+}
+
+output "privateDnsZoneAkvId" {
+  value = module.avm-res-network-privatednszone-akv.resource_id
+}
+
+output "privateDnsZoneAcrId" {
+  value = module.avm-res-network-privatednszone-acr.resource_id
+}

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/input.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/input.tf
@@ -43,12 +43,12 @@ variable "speSubnetId" {
   default = ""
 }
 
-variable "privateDnsZoneAkvId" {
+variable "dnszoneAkvId" {
   type = string
   default = ""
 }
 
-variable "privateDnsZoneAcrId" {
+variable "dnszoneAcrId" {
   type = string
   default = ""
 }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/input.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/input.tf
@@ -1,3 +1,8 @@
+variable "location" {
+  type    = string
+  default = "eastus"
+}
+
 variable "rgLzName" {
   type    = string
   default = "AksTerra-AVM-LZ-RG"
@@ -7,6 +12,7 @@ variable "vnetLzName" {
   type    = string
   default = "vnet-lz"
 }
+
 variable "rgHubName" {
   type    = string
   default = "AksTerra-AVM-Hub-RG"
@@ -19,11 +25,30 @@ variable "vnetHubName" {
 
 variable "acrName" {
   type    = string
-  default = "acrlzti5y"
+  default = "acrlzti5y24"
 }
 
 variable "akvName" {
   type    = string
-  default = "akvlzti5y"
+  default = "akvlzti5y24"
+}
 
+variable "deployingAllInOne" {
+  type    = bool
+  default = false
+}
+
+variable "speSubnetId" {
+  type = string
+  default = ""
+}
+
+variable "privateDnsZoneAkvId" {
+  type = string
+  default = ""
+}
+
+variable "privateDnsZoneAcrId" {
+  type = string
+  default = ""
 }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/main.tf
@@ -52,15 +52,15 @@ module "avm-res-containerregistry-registry" {
   source                        = "Azure/avm-res-containerregistry-registry/azurerm"
   version                       = "0.3.1"
   name                          = var.acrName
-  location                      = var.location # data.azurerm_resource_group.rg.location
-  resource_group_name           = var.rgLzName # data.azurerm_resource_group.rg.name
+  location                      = var.location
+  resource_group_name           = var.rgLzName
   public_network_access_enabled = false
   network_rule_bypass_option    = "AzureServices"
 
   private_endpoints = {
     primary = {
-      private_dns_zone_resource_ids = [local.dnszoneAcrId] # [data.azurerm_private_dns_zone.dnszone-acr.id]
-      subnet_resource_id            = local.speSubnetId    # data.azurerm_subnet.snet-spe.id
+      private_dns_zone_resource_ids = [local.dnszoneAcrId]
+      subnet_resource_id            = local.speSubnetId
     }
   }
 }
@@ -69,14 +69,14 @@ module "avm-res-keyvault-vault" {
   source                        = "Azure/avm-res-keyvault-vault/azurerm"
   version                       = "0.9.1"
   name                          = var.akvName
-  location                      = var.location # data.azurerm_resource_group.rg.location
-  resource_group_name           = var.rgLzName # data.azurerm_resource_group.rg.name
+  location                      = var.location
+  resource_group_name           = var.rgLzName
   tenant_id                     = data.azurerm_client_config.tenant.tenant_id
   public_network_access_enabled = false
   private_endpoints = {
     primary = {
-      private_dns_zone_resource_ids = [local.dnszoneAkvId] # [data.azurerm_private_dns_zone.dnszone-akv.id]
-      subnet_resource_id            = local.speSubnetId    # data.azurerm_subnet.snet-spe.id
+      private_dns_zone_resource_ids = [local.dnszoneAkvId]
+      subnet_resource_id            = local.speSubnetId
     }
   }
 }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/main.tf
@@ -3,33 +3,41 @@ locals {
     akv = "privatelink.vaultcore.azure.net",
     acr = "privatelink.azurecr.io",
     aks = "azurek8s.io"
-
   }
+  
+  speSubnetId = var.deployingAllInOne == true ? var.speSubnetId : data.azurerm_subnet.snet-spe.0.id
+  privateDnsZoneAkvId = var.deployingAllInOne == true ? var.privateDnsZoneAkvId : data.azurerm_private_dns_zone.dnszone-akv.0.id
+  privateDnsZoneAcrId = var.deployingAllInOne == true ? var.privateDnsZoneAcrId : data.azurerm_private_dns_zone.dnszone-acr.0.id
 }
 
 data "azurerm_client_config" "tenant" {}
 
-data "azurerm_resource_group" "rg" {
-  name = var.rgLzName
-}
+# data "azurerm_resource_group" "rg" {
+#   count = var.deployingAllInOne == true ? 0 : 1
+#   name  = var.rgLzName
+# }
 
-data "azurerm_virtual_network" "vnet-lz" {
-  name                = var.vnetLzName
-  resource_group_name = var.rgLzName
-}
+# data "azurerm_virtual_network" "vnet-lz" {
+#   count               = var.deployingAllInOne == true ? 0 : 1
+#   name                = var.vnetLzName
+#   resource_group_name = var.rgLzName
+# }
 
 data "azurerm_subnet" "snet-spe" {
+  count                = var.deployingAllInOne == true ? 0 : 1
   name                 = "snet-spe"
   virtual_network_name = var.vnetLzName
   resource_group_name  = var.rgLzName
 }
 
 data "azurerm_private_dns_zone" "dnszone-acr" {
+  count               = var.deployingAllInOne == true ? 0 : 1
   name                = local.domain_name.acr
   resource_group_name = var.rgLzName
 }
 
 data "azurerm_private_dns_zone" "dnszone-akv" {
+  count               = var.deployingAllInOne == true ? 0 : 1
   name                = local.domain_name.akv
   resource_group_name = var.rgLzName
 }
@@ -44,15 +52,15 @@ module "avm-res-containerregistry-registry" {
   source                        = "Azure/avm-res-containerregistry-registry/azurerm"
   version                       = "0.3.1"
   name                          = var.acrName
-  location                      = data.azurerm_resource_group.rg.location
-  resource_group_name           = data.azurerm_resource_group.rg.name
+  location                      = var.location # data.azurerm_resource_group.rg.location
+  resource_group_name           = var.rgLzName # data.azurerm_resource_group.rg.name
   public_network_access_enabled = false
   network_rule_bypass_option    = "AzureServices"
 
   private_endpoints = {
     primary = {
-      private_dns_zone_resource_ids = [data.azurerm_private_dns_zone.dnszone-acr.id]
-      subnet_resource_id            = data.azurerm_subnet.snet-spe.id
+      private_dns_zone_resource_ids = [local.privateDnsZoneAcrId] # [data.azurerm_private_dns_zone.dnszone-acr.id]
+      subnet_resource_id            = local.speSubnetId # data.azurerm_subnet.snet-spe.id
     }
   }
 }
@@ -61,14 +69,14 @@ module "avm-res-keyvault-vault" {
   source                        = "Azure/avm-res-keyvault-vault/azurerm"
   version                       = "0.9.1"
   name                          = var.akvName
-  location                      = data.azurerm_resource_group.rg.location
-  resource_group_name           = data.azurerm_resource_group.rg.name
+  location                      = var.location # data.azurerm_resource_group.rg.location
+  resource_group_name           = var.rgLzName # data.azurerm_resource_group.rg.name
   tenant_id                     = data.azurerm_client_config.tenant.tenant_id
   public_network_access_enabled = false
   private_endpoints = {
     primary = {
-      private_dns_zone_resource_ids = [data.azurerm_private_dns_zone.dnszone-akv.id]
-      subnet_resource_id            = data.azurerm_subnet.snet-spe.id
+      private_dns_zone_resource_ids = [local.privateDnsZoneAkvId] # [data.azurerm_private_dns_zone.dnszone-akv.id]
+      subnet_resource_id            = local.speSubnetId # data.azurerm_subnet.snet-spe.id
     }
   }
 }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/main.tf
@@ -4,10 +4,10 @@ locals {
     acr = "privatelink.azurecr.io",
     aks = "azurek8s.io"
   }
-  
-  speSubnetId = var.deployingAllInOne == true ? var.speSubnetId : data.azurerm_subnet.snet-spe.0.id
-  privateDnsZoneAkvId = var.deployingAllInOne == true ? var.privateDnsZoneAkvId : data.azurerm_private_dns_zone.dnszone-akv.0.id
-  privateDnsZoneAcrId = var.deployingAllInOne == true ? var.privateDnsZoneAcrId : data.azurerm_private_dns_zone.dnszone-acr.0.id
+
+  speSubnetId  = var.deployingAllInOne == true ? var.speSubnetId : data.azurerm_subnet.snet-spe.0.id
+  dnszoneAkvId = var.deployingAllInOne == true ? var.dnszoneAkvId : data.azurerm_private_dns_zone.dnszone-akv.0.id
+  dnszoneAcrId = var.deployingAllInOne == true ? var.dnszoneAcrId : data.azurerm_private_dns_zone.dnszone-acr.0.id
 }
 
 data "azurerm_client_config" "tenant" {}
@@ -59,8 +59,8 @@ module "avm-res-containerregistry-registry" {
 
   private_endpoints = {
     primary = {
-      private_dns_zone_resource_ids = [local.privateDnsZoneAcrId] # [data.azurerm_private_dns_zone.dnszone-acr.id]
-      subnet_resource_id            = local.speSubnetId # data.azurerm_subnet.snet-spe.id
+      private_dns_zone_resource_ids = [local.dnszoneAcrId] # [data.azurerm_private_dns_zone.dnszone-acr.id]
+      subnet_resource_id            = local.speSubnetId    # data.azurerm_subnet.snet-spe.id
     }
   }
 }
@@ -75,8 +75,8 @@ module "avm-res-keyvault-vault" {
   public_network_access_enabled = false
   private_endpoints = {
     primary = {
-      private_dns_zone_resource_ids = [local.privateDnsZoneAkvId] # [data.azurerm_private_dns_zone.dnszone-akv.id]
-      subnet_resource_id            = local.speSubnetId # data.azurerm_subnet.snet-spe.id
+      private_dns_zone_resource_ids = [local.dnszoneAkvId] # [data.azurerm_private_dns_zone.dnszone-akv.id]
+      subnet_resource_id            = local.speSubnetId    # data.azurerm_subnet.snet-spe.id
     }
   }
 }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/output.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/output.tf
@@ -1,3 +1,11 @@
+output "acrName" {
+  value = module.avm-res-containerregistry-registry.resource.name
+}
+
+output "akvName" {
+  value = module.avm-res-keyvault-vault.resource.name
+}
+
 output "acrId" {
   value = module.avm-res-containerregistry-registry.resource_id
 }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/output.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/output.tf
@@ -1,0 +1,7 @@
+output "acrId" {
+  value = module.avm-res-containerregistry-registry.resource_id
+}
+
+output "akvId" {
+  value = module.avm-res-keyvault-vault.resource_id
+}

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/output.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/05-AKS-Supporting/output.tf
@@ -3,7 +3,8 @@ output "acrName" {
 }
 
 output "akvName" {
-  value = module.avm-res-keyvault-vault.resource.name
+  value = element(split("/", module.avm-res-keyvault-vault.resource_id), 8) 
+#   value = module.avm-res-keyvault-vault.resource.name
 }
 
 output "acrId" {

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/06-AKS-Cluster/input.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/06-AKS-Cluster/input.tf
@@ -37,3 +37,39 @@ variable "akvName" {
   type    = string
   default = "akvlzti5y"
 }
+
+variable "deployingAllInOne" {
+  type    = bool
+  default = false
+}
+
+variable "vnetLzId" {
+  type = string
+  default = ""
+}
+
+variable "snetAksId" {
+  type = string
+  default = ""
+}
+
+
+variable "dnszoneAksId" {
+  type = string
+  default = ""
+}
+
+variable "dnszoneContosoId" {
+  type = string
+  default = ""
+}
+
+variable "acrId" {
+  type = string
+  default = ""
+}
+
+variable "akvId" {
+  type = string
+  default = ""
+}

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/06-AKS-Cluster/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/06-AKS-Cluster/main.tf
@@ -117,7 +117,7 @@ resource "azurerm_kubernetes_cluster" "aks-cluster" {
     dns_zone_ids = [local.dnszoneContosoId] # data.azurerm_private_dns_zone.dnszone-contoso.id]
   }
   azure_active_directory_role_based_access_control {
-    # managed                = true
+    managed                = true
     azure_rbac_enabled     = true
     admin_group_object_ids = [var.adminGroupObjectIds]
   }
@@ -134,11 +134,7 @@ resource "azurerm_kubernetes_cluster" "aks-cluster" {
     only_critical_addons_enabled = true
     vnet_subnet_id               = local.snetAksId # data.azurerm_subnet.snet-aks.id
 
-    zones = [
-      "1",
-      "2",
-      "3",
-    ]
+    zones = ["1", "2", "3"]
   }
   auto_scaler_profile {
     balance_similar_node_groups = true
@@ -181,11 +177,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "nodepool" {
   max_pods              = 250
   mode                  = "User"
   vnet_subnet_id        = local.snetAksId # data.azurerm_subnet.snet-aks.id
-  zones = [
-    "1",
-    "2",
-    "3",
-  ]
+  zones                 = ["1", "2", "3"]
 }
 
 resource "azurerm_role_assignment" "role-assignment-acr" {

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/06-AKS-Cluster/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/06-AKS-Cluster/main.tf
@@ -132,7 +132,7 @@ resource "azurerm_kubernetes_cluster" "aks-cluster" {
     enable_auto_scaling          = true
     max_pods                     = 110
     only_critical_addons_enabled = true
-    vnet_subnet_id               = local.snetAksId # data.azurerm_subnet.snet-aks.id
+    vnet_subnet_id               = local.snetAksId
 
     zones = ["1", "2", "3"]
   }
@@ -180,28 +180,28 @@ resource "azurerm_kubernetes_cluster_node_pool" "nodepool" {
   enable_auto_scaling   = true
   max_pods              = 250
   mode                  = "User"
-  vnet_subnet_id        = local.snetAksId # data.azurerm_subnet.snet-aks.id
+  vnet_subnet_id        = local.snetAksId
   zones                 = ["1", "2", "3"]
 }
 
 resource "azurerm_role_assignment" "role-assignment-acr" {
   principal_id                     = azurerm_kubernetes_cluster.aks-cluster.kubelet_identity[0].object_id
   role_definition_name             = "AcrPull"
-  scope                            = local.acrId # data.azurerm_container_registry.acr.id
+  scope                            = local.acrId
   skip_service_principal_aad_check = true
 }
 
 resource "azurerm_role_assignment" "role-assignment-akv" {
   principal_id                     = azurerm_kubernetes_cluster.aks-cluster.key_vault_secrets_provider[0].secret_identity[0].object_id
   role_definition_name             = "Key Vault Secrets User"
-  scope                            = local.akvId # data.azurerm_key_vault.akv.id
+  scope                            = local.akvId
   skip_service_principal_aad_check = true
 }
 
 resource "azurerm_role_assignment" "role-assignment-private-dns" {
   principal_id                     = azurerm_kubernetes_cluster.aks-cluster.web_app_routing[0].web_app_routing_identity[0].object_id
   role_definition_name             = "Private DNS Zone Contributor"
-  scope                            = local.dnszoneContosoId # data.azurerm_private_dns_zone.dnszone-contoso.id
+  scope                            = local.dnszoneContosoId
   skip_service_principal_aad_check = true
 }
 

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/06-AKS-Cluster/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/06-AKS-Cluster/main.tf
@@ -118,6 +118,7 @@ resource "azurerm_kubernetes_cluster" "aks-cluster" {
   }
   azure_active_directory_role_based_access_control {
     # managed                = true
+    azure_rbac_enabled     = true
     admin_group_object_ids = [var.adminGroupObjectIds]
   }
 

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/06-AKS-Cluster/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/06-AKS-Cluster/main.tf
@@ -165,7 +165,7 @@ resource "azurerm_kubernetes_cluster" "aks-cluster" {
   ]
 
   lifecycle {
-    ignore_changes = [ default_node_pool.upgrade_settings ]
+    ignore_changes = [ default_node_pool.0.upgrade_settings ]
   }
 }
 

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/06-AKS-Cluster/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/06-AKS-Cluster/main.tf
@@ -163,6 +163,10 @@ resource "azurerm_kubernetes_cluster" "aks-cluster" {
   depends_on = [
     azurerm_role_assignment.role-assignment-dnszone,
   ]
+
+  lifecycle {
+    ignore_changes = [ default_node_pool.upgrade_settings ]
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "nodepool" {

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/Readme.md
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/Readme.md
@@ -1,3 +1,3 @@
 # Deploying the Hub and Landing Zone in one one Terraform template
 
-If you are looking for to deploy all resources, the Hub and Spoke components, in one `terraform` template, then the template presented in this folder will do exactly that. It will deploy all the 4 steps (`03-Network-Hub`, `04-Network-LZ`, `05-AKS-Supporting` and `06-AKS-Cluster`) as 4 modules. 
+If you are looking to deploy all resources, the Hub and Spoke components, in one `terraform` template, then the template presented in this folder will do exactly that. It will deploy all the 4 steps (`03-Network-Hub`, `04-Network-LZ`, `05-AKS-Supporting` and `06-AKS-Cluster`) as 4 modules. 

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/Readme.md
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/Readme.md
@@ -1,0 +1,3 @@
+# Deploying the Hub and Landing Zone in one one Terraform template
+
+If you are looking for to deploy all resources, the Hub and Spoke components, in one `terraform` template, then the template presented in this folder will do exactly that. It will deploy all the 4 steps (`03-Network-Hub`, `04-Network-LZ`, `05-AKS-Supporting` and `06-AKS-Cluster`) as 4 modules. 

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/input.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/input.tf
@@ -32,7 +32,7 @@ variable "hubVNETaddPrefixes" {
   default = "10.0.0.0/16"
 }
 
-variable "snetDefaultAddr" {
+variable "snetHubDefaultAddr" {
   type    = string
   default = "10.0.0.0/24"
 }
@@ -90,6 +90,11 @@ variable "nsgAppGWName" {
 variable "spokeVNETaddPrefixes" {
   type    = string
   default = "10.1.0.0/16"
+}
+
+variable "snetSpokeDefaultAddr" {
+  type    = string
+  default = "10.1.0.0/24"
 }
 
 variable "snetAksAddr" {

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/input.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/input.tf
@@ -8,7 +8,17 @@ variable "rgHubName" {
   default = "AksTerra-AVM-Hub-RG"
 }
 
+variable "rgLzName" {
+  type    = string
+  default = "AksTerra-AVM-LZ-RG"
+}
+
 variable "nsgHubDefaultName" {
+  type    = string
+  default = "nsg-default"
+}
+
+variable "nsgLzDefaultName" {
   type    = string
   default = "nsg-default"
 }
@@ -52,6 +62,11 @@ variable "vnetHubName" {
   default = "vnet-hub"
 }
 
+variable "vnetLzName" {
+  type    = string
+  default = "vnet-lz"
+}
+
 variable "availabilityZones" {
   type    = list(string)
   default = ["1", "2", "3"]
@@ -60,4 +75,39 @@ variable "availabilityZones" {
 variable "rtHubName" {
   type    = string
   default = "rt-hub-table"
+}
+
+variable "rtLzName" {
+  type    = string
+  default = "rt-hub-table"
+}
+
+variable "nsgAppGWName" {
+  type    = string
+  default = "nsg-appgw"
+}
+
+variable "spokeVNETaddPrefixes" {
+  type    = string
+  default = "10.1.0.0/16"
+}
+
+variable "snetAksAddr" {
+  type    = string
+  default = "10.1.1.0/26"
+}
+
+variable "snetAppGWAddr" {
+  type    = string
+  default = "10.1.2.0/27"
+}
+
+variable "acrName" {
+  type    = string
+  default = "acrlzti5y24"
+}
+
+variable "akvName" {
+  type    = string
+  default = "akvlzti5y24"
 }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/input.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/input.tf
@@ -116,3 +116,8 @@ variable "akvName" {
   type    = string
   default = "akvlzti5y24"
 }
+
+variable "adminGroupObjectIds" {
+  type    = string
+  default = ""
+}

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/main.tf
@@ -50,21 +50,30 @@ module "aksSupporting" {
   acrName     = var.acrName
   akvName     = var.akvName
 
-  deployingAllInOne   = true
-  speSubnetId         = module.networkLZ.speSubnetId
-  privateDnsZoneAkvId = module.networkLZ.privateDnsZoneAkvId
-  privateDnsZoneAcrId = module.networkLZ.privateDnsZoneAcrId
+  deployingAllInOne = true
+  speSubnetId       = module.networkLZ.speSubnetId
+  dnszoneAkvId      = module.networkLZ.dnszoneAkvId
+  dnszoneAcrId      = module.networkLZ.dnszoneAcrId
 }
 
-# module "aksCluster" {
-#   source = "../06-AKS-Cluster/"
+module "aksCluster" {
+  source = "../06-AKS-Cluster/"
 
-#   location    = var.location
-#   rgLzName    = var.rgLzName
-#   vnetLzName  = var.vnetLzName
-#   rgHubName   = var.rgHubName
-#   vnetHubName = var.vnetHubName
-#   acrName     = var.acrName
-#   akvName     = var.akvName
-#   adminGroupObjectIds = ""
-# }
+  location            = var.location
+  rgLzName            = var.rgLzName
+  vnetLzName          = var.vnetLzName
+  rgHubName           = var.rgHubName
+  vnetHubName         = var.vnetHubName
+  acrName             = var.acrName
+  akvName             = var.akvName
+  adminGroupObjectIds = var.adminGroupObjectIds
+
+
+  deployingAllInOne = true
+  vnetLzId          = module.networkLZ.vnetLzId
+  snetAksId         = module.networkLZ.snetAksId
+  dnszoneAksId      = module.networkLZ.dnszoneAksId
+  dnszoneContosoId  = module.networkLZ.dnszoneContosoId
+  acrId             = module.aksSupporting.acrId
+  akvId             = module.aksSupporting.akvId
+}

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/main.tf
@@ -6,7 +6,7 @@ module "networkHub" {
   nsgHubDefaultName  = var.nsgHubDefaultName
   nsgVMName          = var.nsgVMName
   hubVNETaddPrefixes = var.hubVNETaddPrefixes
-  snetDefaultAddr    = var.snetDefaultAddr
+  snetDefaultAddr    = var.snetHubDefaultAddr
   snetFirewallAddr   = var.snetFirewallAddr
   snetBastionAddr    = var.snetBastionAddr
   snetVMAddr         = var.snetVMAddr
@@ -16,31 +16,48 @@ module "networkHub" {
   rtHubName          = var.rtHubName
 }
 
-# module "networkLZ" {
-#   source = "../04-Network-LZ/"
+module "networkLZ" {
+  source = "../04-Network-LZ/"
 
-#   location             = var.location
-#   rgLzName             = var.rgLzName
-#   rgHubName            = module.networkHub.rgHubName   # var.rgHubName
-#   vnetHubName          = module.networkHub.vnetHubName # var.vnetHubName
-#   vnetLzName           = var.vnetLzName
-#   rtLzName             = var.rtLzName
-#   nsgLzDefaultName     = var.nsgLzDefaultName
-#   nsgAppGWName         = var.nsgAppGWName
-#   spokeVNETaddPrefixes = var.spokeVNETaddPrefixes
-#   snetDefaultAddr      = var.snetDefaultAddr
-#   snetAksAddr          = var.snetAksAddr
-#   snetAppGWAddr        = var.snetAppGWAddr
+  location             = var.location
+  rgLzName             = var.rgLzName
+  rgHubName            = module.networkHub.rgHubName   # var.rgHubName
+  vnetHubName          = module.networkHub.vnetHubName # var.vnetHubName
+  vnetLzName           = var.vnetLzName
+  rtLzName             = var.rtLzName
+  nsgLzDefaultName     = var.nsgLzDefaultName
+  nsgAppGWName         = var.nsgAppGWName
+  spokeVNETaddPrefixes = var.spokeVNETaddPrefixes
+  snetDefaultAddr      = var.snetSpokeDefaultAddr
+  snetAksAddr          = var.snetAksAddr
+  snetAppGWAddr        = var.snetAppGWAddr
 
-#   deployingAllInOne = true
-#   vnetHubId         = module.networkHub.vnetHubId
-#   firewallPrivateIp = module.networkHub.firewallPrivateIp
+  deployingAllInOne = true
+  vnetHubId         = module.networkHub.vnetHubId
+  firewallPrivateIp = module.networkHub.firewallPrivateIp
 
-#   # depends_on = [module.networkHub]
-# }
+  # depends_on = [module.networkHub]
+}
 
-# module "aksSupporting" {
-#   source = "../05-AKS-Supporting/"
+module "aksSupporting" {
+  source = "../05-AKS-Supporting/"
+
+  location    = var.location
+  rgLzName    = var.rgLzName
+  vnetLzName  = var.vnetLzName
+  rgHubName   = var.rgHubName
+  vnetHubName = var.vnetHubName
+  acrName     = var.acrName
+  akvName     = var.akvName
+
+  deployingAllInOne   = true
+  speSubnetId         = module.networkLZ.speSubnetId
+  privateDnsZoneAkvId = module.networkLZ.privateDnsZoneAkvId
+  privateDnsZoneAcrId = module.networkLZ.privateDnsZoneAcrId
+}
+
+# module "aksCluster" {
+#   source = "../06-AKS-Cluster/"
 
 #   location    = var.location
 #   rgLzName    = var.rgLzName
@@ -49,9 +66,5 @@ module "networkHub" {
 #   vnetHubName = var.vnetHubName
 #   acrName     = var.acrName
 #   akvName     = var.akvName
-
-#   deployingAllInOne   = true
-#   speSubnetId         = module.networkLZ.speSubnetId
-#   privateDnsZoneAkvId = module.networkLZ.privateDnsZoneAkvId
-#   privateDnsZoneAcrId = module.networkLZ.privateDnsZoneAcrId
+#   adminGroupObjectIds = ""
 # }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/main.tf
@@ -35,18 +35,16 @@ module "networkLZ" {
   deployingAllInOne = true
   vnetHubId         = module.networkHub.vnetHubId
   firewallPrivateIp = module.networkHub.firewallPrivateIp
-
-  # depends_on = [module.networkHub]
 }
 
 module "aksSupporting" {
   source = "../05-AKS-Supporting/"
 
   location    = var.location
-  rgLzName    = var.rgLzName
-  vnetLzName  = var.vnetLzName
-  rgHubName   = var.rgHubName
-  vnetHubName = var.vnetHubName
+  rgLzName    = module.networkLZ.rgLzName     # var.rgLzName
+  vnetLzName  = module.networkLZ.vnetLzName   # var.vnetLzName
+  rgHubName   = module.networkHub.rgHubName   # var.rgHubName
+  vnetHubName = module.networkHub.vnetHubName # var.vnetHubName
   acrName     = var.acrName
   akvName     = var.akvName
 
@@ -60,12 +58,12 @@ module "aksCluster" {
   source = "../06-AKS-Cluster/"
 
   location            = var.location
-  rgLzName            = var.rgLzName
-  vnetLzName          = var.vnetLzName
-  rgHubName           = var.rgHubName
-  vnetHubName         = var.vnetHubName
-  acrName             = var.acrName
-  akvName             = var.akvName
+  rgLzName            = module.networkLZ.rgLzName     # var.rgLzName
+  vnetLzName          = module.networkLZ.vnetLzName   # var.vnetLzName
+  rgHubName           = module.networkHub.rgHubName   # var.rgHubName
+  vnetHubName         = module.networkHub.vnetHubName # var.vnetHubName
+  acrName             = module.aksSupporting.acrName  # var.acrName
+  akvName             = module.aksSupporting.akvName  # var.akvName
   adminGroupObjectIds = var.adminGroupObjectIds
 
 

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/main.tf
@@ -1,0 +1,57 @@
+module "networkHub" {
+  source = "../03-Network-Hub/"
+
+  location           = var.location
+  rgHubName          = var.rgHubName
+  nsgHubDefaultName  = var.nsgHubDefaultName
+  nsgVMName          = var.nsgVMName
+  hubVNETaddPrefixes = var.hubVNETaddPrefixes
+  snetDefaultAddr    = var.snetDefaultAddr
+  snetFirewallAddr   = var.snetFirewallAddr
+  snetBastionAddr    = var.snetBastionAddr
+  snetVMAddr         = var.snetVMAddr
+  routeAddr          = var.routeAddr
+  vnetHubName        = var.vnetHubName
+  availabilityZones  = var.availabilityZones
+  rtHubName          = var.rtHubName
+}
+
+# module "networkLZ" {
+#   source = "../04-Network-LZ/"
+
+#   location             = var.location
+#   rgLzName             = var.rgLzName
+#   rgHubName            = module.networkHub.rgHubName   # var.rgHubName
+#   vnetHubName          = module.networkHub.vnetHubName # var.vnetHubName
+#   vnetLzName           = var.vnetLzName
+#   rtLzName             = var.rtLzName
+#   nsgLzDefaultName     = var.nsgLzDefaultName
+#   nsgAppGWName         = var.nsgAppGWName
+#   spokeVNETaddPrefixes = var.spokeVNETaddPrefixes
+#   snetDefaultAddr      = var.snetDefaultAddr
+#   snetAksAddr          = var.snetAksAddr
+#   snetAppGWAddr        = var.snetAppGWAddr
+
+#   deployingAllInOne = true
+#   vnetHubId         = module.networkHub.vnetHubId
+#   firewallPrivateIp = module.networkHub.firewallPrivateIp
+
+#   # depends_on = [module.networkHub]
+# }
+
+# module "aksSupporting" {
+#   source = "../05-AKS-Supporting/"
+
+#   location    = var.location
+#   rgLzName    = var.rgLzName
+#   vnetLzName  = var.vnetLzName
+#   rgHubName   = var.rgHubName
+#   vnetHubName = var.vnetHubName
+#   acrName     = var.acrName
+#   akvName     = var.akvName
+
+#   deployingAllInOne   = true
+#   speSubnetId         = module.networkLZ.speSubnetId
+#   privateDnsZoneAkvId = module.networkLZ.privateDnsZoneAkvId
+#   privateDnsZoneAcrId = module.networkLZ.privateDnsZoneAcrId
+# }

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/main.tf
@@ -66,7 +66,6 @@ module "aksCluster" {
   akvName             = module.aksSupporting.akvName  # var.akvName
   adminGroupObjectIds = var.adminGroupObjectIds
 
-
   deployingAllInOne = true
   vnetLzId          = module.networkLZ.vnetLzId
   snetAksId         = module.networkLZ.snetAksId

--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/providers.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/All-in-One/providers.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = "~> 1.6"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.74"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.4"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}


### PR DESCRIPTION
Added a new folder called All-in-One from which all 4 steps (03-Network-Hub, 04-Network-LZ, 05-AKS-Supporting and 06-AKS-Cluster) are deployed as modules in just one template.
The changes are beneficial because it simplifies the deployment process and reduces the number of steps required to deploy the infrastructure.
I've changed the config of the existing templates, added input variables that takes the resource ID from the resources created in previous modules.