### PR TITLE
Fix #162: Resolve provider version conflict in 03-Network-Hub

### DIFF
--- a/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/03-Network-Hub/main.tf
+++ b/Scenarios/AKS-Secure-Baseline-PrivateCluster/Terraform/03-Network-Hub/main.tf
@@ -295,7 +295,7 @@ module "avm-res-network-azurefirewall" {
 
 module "azure_bastion" {
   source = "Azure/avm-res-network-bastionhost/azurerm"
-
+  version = "0.3.0"
   name                = "bastion"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location


### PR DESCRIPTION
### Fix for Provider Version Conflict in 03-Network-Hub Module This PR addresses the issue described in #162, where the `azure_bastion` module causes a provider version conflict for `azurerm`. The conflict arises due to differing provider version constraints between the root module and the `Azure/avm-res-network-routetable/azurerm` module.

#### Changes Made:
1. Updated the `main.tf` in the root module to ensure consistent provider constraints by adding version attribute with the value 0.3.0: 

```hcl
module "azure_bastion" {
  source = "Azure/avm-res-network-bastionhost/azurerm"
  version = "0.3.0"
  name                = "bastion"
  resource_group_name = azurerm_resource_group.rg.name
  location            = azurerm_resource_group.rg.location
  copy_paste_enabled  = true
  file_copy_enabled   = false
  sku                 = "Standard"
  ip_configuration = {
    name                 = "bastion-ipconfig"
    subnet_id            = module.avm-res-network-virtualnetwork.subnets["AzureBastionSubnet"].resource_id
    public_ip_address_id = module.publicIpBastion.public_ip_id
  }
  ip_connect_enabled     = true
  scale_units            = 4
  shareable_link_enabled = true
  tunneling_enabled      = true
  kerberos_enabled       = false
}
```

#### Testing:
Verified the changes with 
`terraform init `
and 
`terraform plan `
in the affected module.
