### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/1-deploy-infrastructure.yml
+++ b/.github/workflows/1-deploy-infrastructure.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
         
       - name: Azure Login
-        uses: Azure/login@v2
+        uses: Azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
         if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != ''}}
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
@@ -59,7 +59,7 @@ jobs:
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Remove previous resources
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         if: ${{ inputs.DELETE_EXISTING_RESOURCES }}
         continue-on-error: true
         with:
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@main
 
       - name: Update Variables in IaC Templates
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -104,7 +104,7 @@ jobs:
            
       - name: Create ESLZ Hub
         if: ${{ env.AZURE_SUBSCRIPTION_ID != '' }}
-        uses: azure/arm-deploy@v2
+        uses: azure/arm-deploy@a1361c2c2cd398621955b16ca32e01c65ea340f5 # v2.0.0
         with:
           deploymentName: ESLZ-HUB
           scope: subscription
@@ -116,7 +116,7 @@ jobs:
           failOnStdErr: false
 
       - name: Get CIDR of VM Subnet
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -125,7 +125,7 @@ jobs:
             echo 'VM_SUBNET_CIDR='$VM_SUBNET_CIDR >> $GITHUB_ENV
 
       - name: Update Firewall to allow VMs out
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -137,7 +137,7 @@ jobs:
             
       - name: Create Jumpbox VM
         if: ${{ env.AZURE_SUBSCRIPTION_ID != '' && env.VM_PW != '' }}
-        uses: azure/arm-deploy@v2
+        uses: azure/arm-deploy@a1361c2c2cd398621955b16ca32e01c65ea340f5 # v2.0.0
         with:
           deploymentName: ESLZ-HUB-VM
           template: ${{ env.BICEP_ROOT_PATH }}03-Network-Hub/deploy-vm.bicep
@@ -150,7 +150,7 @@ jobs:
             
       - name: Create GitHub Runner VM
         if: ${{ env.AZURE_SUBSCRIPTION_ID != '' && env.VM_PW != '' && env.VM_PW != '' &&  env.GH_TOKEN != '' }}
-        uses: azure/arm-deploy@v2
+        uses: azure/arm-deploy@a1361c2c2cd398621955b16ca32e01c65ea340f5 # v2.0.0
         with:
           deploymentName: ESLZ-HUB-RUNNER
           template: ${{ env.BICEP_ROOT_PATH }}03-Network-Hub/deploy-runner.bicep
@@ -180,7 +180,7 @@ jobs:
             echo 'STORAGE_ACCOUNT_NAME=s'$(uuidgen) | sed 's/-//g' | cut -c 1-45 >> $GITHUB_ENV
 
       - name: Create Spoke
-        uses: azure/arm-deploy@v2
+        uses: azure/arm-deploy@a1361c2c2cd398621955b16ca32e01c65ea340f5 # v2.0.0
         with:
           deploymentName: ESLZ-SPOKE
           template: ${{ env.BICEP_ROOT_PATH }}04-Network-LZ/main.bicep
@@ -192,7 +192,7 @@ jobs:
           failOnStdErr: false            
             
       - name: Create AKS Supporting Resources in Spoke
-        uses: azure/arm-deploy@v2
+        uses: azure/arm-deploy@a1361c2c2cd398621955b16ca32e01c65ea340f5 # v2.0.0
         with:
           deploymentName: ESLZ-SPOKE-AKS-SUPPORTING
           template: ${{ env.BICEP_ROOT_PATH }}05-AKS-supporting/main.bicep
@@ -204,7 +204,7 @@ jobs:
           failOnStdErr: false            
 
       - name: Set Environment Variables
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -217,14 +217,14 @@ jobs:
 
       - name: Azure Log out
         if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != ''}}
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           inlineScript: |
           
             az logout
 
       - name: Azure Login
-        uses: Azure/login@v2
+        uses: Azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
         if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != ''}}
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
@@ -232,14 +232,14 @@ jobs:
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Configure AKS Subnet
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           inlineScript: |
 
              az network vnet subnet update --vnet-name ${{ env.SPOKE_VNET_NAME }} --name ${{ env.AKS_SUBNET }} --resource-group ${{ env.SPOKE_RESOURCE_GROUP }} --route-table ${{ env.AKS_ROUTE_TABLE }} --network-security-group ${{ env.AKS_NSG }}
 
       - name: Configure Application Gateway Subnet
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
            timeout_seconds: 300
            max_attempts: 5
@@ -249,7 +249,7 @@ jobs:
              az network vnet subnet update --vnet-name ${{ env.SPOKE_VNET_NAME }} --name ${{ env.APP_GW_SUBNET }} --resource-group ${{ env.SPOKE_RESOURCE_GROUP }} --route-table ${{ env.APP_GW_ROUTE_TABLE }} --network-security-group ${{ env.APP_GW_NSG }}
 
       - name: Deploy AKS in Spoke
-        uses: azure/arm-deploy@v2
+        uses: azure/arm-deploy@a1361c2c2cd398621955b16ca32e01c65ea340f5 # v2.0.0
         with:
           deploymentName: ESLZ-AKS-CLUSTER
           template: ${{ env.BICEP_ROOT_PATH }}06-AKS-cluster/main.bicep
@@ -262,7 +262,7 @@ jobs:
           failOnStdErr: false            
 
       - name: Set AKS Environment Variables
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -283,7 +283,7 @@ jobs:
             echo 'SUBNET_ID='$SUBNET_ID >> $GITHUB_ENV
             
       - name: Enable AKS Auto-Upgrade
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -291,7 +291,7 @@ jobs:
             az aks update --resource-group ${{ env.SPOKE_RESOURCE_GROUP }} --name ${{ env.CLUSTER_NAME }} --auto-upgrade-channel stable
       
       - name: Assign Permissions to GitHub Runner VM's Managed identity
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         if: ${{ env.AKS_ID != '' && env.RUNNER_MANAGED_IDENTITY_PRINCIPAL_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' }}
         with:
           azcliversion: latest
@@ -310,7 +310,7 @@ jobs:
             az keyvault set-policy --name ${{ env.KEYVAULT_NAME }} --object-id ${{ env.RUNNER_MANAGED_IDENTITY_PRINCIPAL_ID }} --secret-permissions set --resource-group ${{ env.SPOKE_RESOURCE_GROUP }}
 
       - name: Create Custom DNS
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -322,7 +322,7 @@ jobs:
             az network private-dns link vnet create --resource-group ${{ env.HUB_RESOURCE_GROUP }} --name ${{ env.PRIVATE_DNS_NAME }}-link-hub --zone ${{ env.PRIVATE_DNS_NAME }} --virtual-network ${{ env.HUB_VNET_NAME }} --registration-enabled true
             
       - name: Update Firewall to allow AKS out
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -334,7 +334,7 @@ jobs:
             az network firewall application-rule create --collection-name 'aks-egress' --name 'Allow-HTTPS' --target-fqdns '*' --firewall-name ${{ env.FIREWALL_NAME }} --protocols Https=443 --resource-group ${{ env.HUB_RESOURCE_GROUP }} --source-addresses '${{ env.AKS_SUBNET_CIDR }}'  --priority 350 --action Allow
             
       - name: Cap Log Analytics Workspace Ingress to save $
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -342,7 +342,7 @@ jobs:
             az monitor log-analytics workspace update --resource-group ${{ env.SPOKE_RESOURCE_GROUP }} --workspace-name ${{ env.LOG_ANALYTICS_WORKSPACE_NAME }} --quota 5
 
       - name: Enable Auto-Scaler on Default Node Pool to save $
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -350,7 +350,7 @@ jobs:
             az aks nodepool update --resource-group ${{ env.SPOKE_RESOURCE_GROUP }} --name defaultpool --cluster-name ${{ env.CLUSTER_NAME }} --enable-cluster-autoscaler --min-count 2 --max-count 5
 
       - name: Log out
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           inlineScript: |
           

--- a/.github/workflows/2-deploy-workload.yml
+++ b/.github/workflows/2-deploy-workload.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
 
       - name: Install K8s Extension
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         continue-on-error: true
         with:
           azcliversion: latest
@@ -40,7 +40,7 @@ jobs:
             az extension update --name k8s-extension
 
       - name: Install Common Services onto AKS
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -70,7 +70,7 @@ jobs:
             echo 'MongoDB_Password='$(uuidgen) >> $GITHUB_ENV
 
       - name: Find ACR Name
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -80,7 +80,7 @@ jobs:
             echo 'ACR_NAME='$ACR_NAME >> $GITHUB_ENV
 
       - name: Create Agent Pool
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -89,7 +89,7 @@ jobs:
             az acr agentpool create --registry ${{ env.ACR_NAME }} --name ${{ env.AGENT_POOL_NAME }} --tier ${{ env.AGENT_POOL_TIER }} --count ${{ env.AGENT_POOL_COUNT }} --subnet-id $subnetId
 
       - name: Find KeyVault Name
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -98,7 +98,7 @@ jobs:
             echo 'KEYVAULT_NAME='$KEYVAULT_NAME >> $GITHUB_ENV
 
       - name: Get the clientId of the azure-keyvault-secrets-provider User Assigned Managed Identity
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -107,7 +107,7 @@ jobs:
             echo 'azureKeyvaultSecretsProviderUserAssignedManagedIdentityClientId='$azureKeyvaultSecretsProviderUserAssignedManagedIdentityClientId >> $GITHUB_ENV
             
       - name: Store MongoDb Connection String in KeyVault
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -115,7 +115,7 @@ jobs:
             az keyvault secret set --name mongodburi --vault-name ${{ env.KEYVAULT_NAME }} --value "mongodb://${{ env.MONGO_DB_USER }}:${{ env.MongoDB_Password }}@ratings-mongodb.ratingsapp:27017/ratingsdb"
 
       - name: Build and Push web app using the ACR and agent pool
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -123,7 +123,7 @@ jobs:
             az acr build --no-logs --agent-pool ${{ env.AGENT_POOL_NAME }} --image ratings-web:v1 --registry ${{ env.ACR_NAME }} --file Dockerfile https://github.com/MicrosoftDocs/mslearn-aks-workshop-ratings-web.git#master
 
       - name: Build and Push api app to ACR using agent pool
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -131,7 +131,7 @@ jobs:
             az acr build --no-logs --agent-pool ${{ env.AGENT_POOL_NAME }} --image ratings-api:v1 --registry ${{ env.ACR_NAME }} --file Dockerfile https://github.com/ivegamsft/mslearn-aks-workshop-ratings-api.git#master
 
       - name: Delete Agent Pool to save $
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -153,7 +153,7 @@ jobs:
           find . -type f -exec sed -i 's/<your e-mail here>/${{ env.EMAIL }}/g' {} +
 
       - name: Deploy NGINX
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -162,7 +162,7 @@ jobs:
             az aks command invoke --resource-group ${{ env.SPOKE_RESOURCE_GROUP }} --name ${{ env.CLUSTER_NAME }} --command "helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx && helm repo update && helm install ingress-nginx ingress-nginx/ingress-nginx --set controller.service.annotations.'service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path=/healthz' -f internal-ingress.yaml" --file $GITHUB_WORKSPACE/Scenarios/AKS-Secure-Baseline-PrivateCluster/Apps/RatingsApp/internal-ingress.yaml
 
       - name: Deploy Web and API App & Expose Internally
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -184,7 +184,7 @@ jobs:
             echo 'Random_DNS=z'$(uuidgen) | sed 's/-//g' >> $GITHUB_ENV
 
       - name: Update DNS of our Application Gateway Public IP
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -202,7 +202,7 @@ jobs:
           find . -type f -exec sed -i 's/<your e-mail here>/${{ env.EMAIL }}/g' {} +
 
       - name: Deploy Certificate Issuer and Public Ingress using Application Gateway
-        uses: Azure/CLI@v2
+        uses: Azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -211,7 +211,7 @@ jobs:
             az aks command invoke --resource-group ${{ env.SPOKE_RESOURCE_GROUP }} --name ${{ env.CLUSTER_NAME }} --command "kubectl apply -f 5-https-ratings-web-ingress.yaml -n ratingsapp" --file $GITHUB_WORKSPACE/Scenarios/AKS-Secure-Baseline-PrivateCluster/Apps/RatingsApp/5-https-ratings-web-ingress.yaml
 
       - name: Log out
-        uses: azure/CLI@v2
+        uses: azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         with:
           inlineScript: |
           

--- a/.github/workflows/brokenlinks.yml
+++ b/.github/workflows/brokenlinks.yml
@@ -12,11 +12,11 @@ jobs:
   repoLinkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.5.1
+        uses: lycheeverse/lychee-action@4a5af7cd2958a2282cefbd9c10f63bdb89982d76 # v1.5.1
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
@@ -25,7 +25,7 @@ jobs:
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@433e51abf769039ee20ba1293a088ca19d573b7f # v4.0.1
         with:
           title: 'Bot: Broken Links Detected in Repo'
           content-filepath: ./lychee/out.md

--- a/.github/workflows/deploy-openai-embeddings-app.yaml
+++ b/.github/workflows/deploy-openai-embeddings-app.yaml
@@ -24,10 +24,10 @@ jobs:
             id-token: write
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
               with:
                 submodules: 'true'
-            - uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2
+            - uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.7
               name: Azure login
               with:
                 client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -44,18 +44,18 @@ jobs:
         needs:
          - buildImage
         steps:
-            - uses: actions/checkout@v3
-            - uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2
+            - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+            - uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.7
               name: Azure login
               with:
                 client-id: ${{ secrets.AZURE_CLIENT_ID }}
                 subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
                 tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-            - uses: azure/use-kubelogin@v1
+            - uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
               name: Set up kubelogin for non-interactive login
               with:
                 kubelogin-version: v0.0.25
-            - uses: azure/aks-set-context@v3
+            - uses: azure/aks-set-context@4edaee69f820359371ee8bc85189ac03a21d3a58 # v3.2
               name: Get K8s context
               with:
                 admin: "false"
@@ -81,7 +81,7 @@ jobs:
                 
             # Runs Kustomize to create manifest files
             - name: Bake deployment
-              uses: azure/k8s-bake@v2
+              uses: azure/k8s-bake@24950e3f44c69c914261e3028a0fcd0fdcd93690 # v2.4
               with:
                 renderEngine: "kustomize"
                 kustomizationPath: ${{ env.KUSTOMIZE_PATH }}
@@ -90,7 +90,7 @@ jobs:
 
             # Deploys application based on manifest files from previous step
             - name: Deploy application
-              uses: Azure/k8s-deploy@v4
+              uses: Azure/k8s-deploy@1082a9290dd683dfe1d60582f418a27684e3a391 # v4.10
               with:
                 action: deploy
                 manifests: ${{ steps.bake.outputs.manifestsBundle }}

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -10,9 +10,9 @@ jobs:
   MustPass:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.5.0
+      - uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
 
-      - uses: streetsidesoftware/cspell-action@v2.12.1
+      - uses: streetsidesoftware/cspell-action@f289d32d6267fbb1d23fb8e4b66905fc7c63cac4 # v2.12.1
         name: Spell Check
         with:
           config: './.vscode/cspell.json'


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
